### PR TITLE
Add nicer message when there are unchecked changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,9 +45,12 @@ forEachPackage(rootDir, function(packageName, packagePath) {
 
     var promise = Git.Repository.open(packagePath).then(function(repo) {
         var hasUncommittedChanges = false;
+        var messages = [];
         return Git.Status.foreach(repo, function(file, status) {
             if (status !== Git.Status.STATUS.IGNORED) {
                 hasUncommittedChanges = true;
+                var statusTexts = Object.keys(Git.Status.STATUS).filter(function(key) {return Git.Status.STATUS[key] & status;});
+                messages.push('    * ' + file + ': ' + statusTexts.join(', '));
             }
         }).then(function(config) {
             repo.free();
@@ -56,6 +59,7 @@ forEachPackage(rootDir, function(packageName, packagePath) {
 
             return {
                 hasUncommittedChanges: hasUncommittedChanges,
+                messages: messages,
                 packageName: packageName,
                 packagePath: packagePath,
                 original: gitDir,
@@ -78,6 +82,7 @@ Promise.all(promises).then(function(mappings) {
         console.log('The following packages have uncommitted changes:');
         uncommittedPackages.forEach(function(mapping) {
             console.log('  ' + mapping.packagePath);
+            console.log(mapping.messages.join('\n'));
         });
         console.log('Please ensure all packages with a git repository have a clean working directory.')
     }


### PR DESCRIPTION
This displays the files causing the "uncommitted changes" warning, and the reason. This is useful on case-insensitive systems (like a Mac), where `git status` can be different to what `nodegit` says.

```
$ npmgitdev install
The following packages have uncommitted changes:
  /.../nationalmap/node_modules/terriajs
    * lib/Models/CustomComponents.js: WT_DELETED
Please ensure all packages with a git repository have a clean working directory.
```
