### PR TITLE
Upgrade nodegit to support node 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/TerriaJS/npmgitdev#readme",
   "dependencies": {
-    "nodegit": "^0.14.1"
+    "nodegit": "^0.18.0"
   },
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
@kring `npmgitdev` is the only tool I use that doesn't work on node 7 now. Could you make a new release that does? I've been using my own local version that used `nodegit@0.16.0` for a while and it's fine, and I tested 0.18.0 once or twice and it worked.